### PR TITLE
Add interfaces for DEVICE_CLASS_GATE and tests

### DIFF
--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -408,7 +408,7 @@ class CoverCapabilities(AlexaEntity):
     def interfaces(self):
         """Yield the supported interfaces."""
         device_class = self.entity.attributes.get(ATTR_DEVICE_CLASS)
-        if device_class != cover.DEVICE_CLASS_GARAGE:
+        if device_class not in (cover.DEVICE_CLASS_GARAGE, cover.DEVICE_CLASS_GATE):
             yield AlexaPowerController(self.entity)
 
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -2612,7 +2612,7 @@ async def test_cover_garage_door(hass):
     """Test garage door cover discovery."""
     device = (
         "cover.test_garage_door",
-        "off",
+        "closed",
         {
             "friendly_name": "Test cover garage door",
             "supported_features": 3,
@@ -2624,6 +2624,28 @@ async def test_cover_garage_door(hass):
     assert appliance["endpointId"] == "cover#test_garage_door"
     assert appliance["displayCategories"][0] == "GARAGE_DOOR"
     assert appliance["friendlyName"] == "Test cover garage door"
+
+    assert_endpoint_capabilities(
+        appliance, "Alexa.ModeController", "Alexa.EndpointHealth", "Alexa"
+    )
+
+
+async def test_cover_gate(hass):
+    """Test cover with device class gate discovery."""
+    device = (
+        "cover.test_gate",
+        "closed",
+        {
+            "friendly_name": "Test cover gate",
+            "supported_features": 3,
+            "device_class": "gate",
+        },
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert appliance["endpointId"] == "cover#test_gate"
+    assert appliance["displayCategories"][0] == "GARAGE_DOOR"
+    assert appliance["friendlyName"] == "Test cover gate"
 
     assert_endpoint_capabilities(
         appliance, "Alexa.ModeController", "Alexa.EndpointHealth", "Alexa"


### PR DESCRIPTION
Adds interfaces in Alexa for `DEVICE_CLASS_GATE` and adds a test.

Note that in Alexa, using the Display Category `GARAGE` will enable the Voice PIN option for any `DEVICE_CLASS_GATE`. 